### PR TITLE
Provide one text object instead of of two

### DIFF
--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -31,10 +31,10 @@ vnoremap <silent>ai :<C-u>cal <Sid>HandleTextObjectMapping(0, 1, 1, [line("'<"),
 vnoremap <silent>ii :<C-u>cal <Sid>HandleTextObjectMapping(1, 1, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
 
 " Mappings excluding line below (for specific file types (like Python))
-au FileType python,coffee,haml onoremap <buffer><silent>ai :<C-u>cal <Sid>HandleTextObjectMapping(0, 0, 0, [line("."), line("."), col("."), col(".")])<CR>
-au FileType python,coffee,haml onoremap <buffer><silent>ii :<C-u>cal <Sid>HandleTextObjectMapping(1, 0, 0, [line("."), line("."), col("."), col(".")])<CR>
-au FileType python,coffee,haml vnoremap <buffer><silent>ai :<C-u>cal <Sid>HandleTextObjectMapping(0, 0, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
-au FileType python,coffee,haml vnoremap <buffer><silent>ii :<C-u>cal <Sid>HandleTextObjectMapping(1, 0, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
+au FileType python,coffee,haml,yaml,slim onoremap <buffer><silent>ai :<C-u>cal <Sid>HandleTextObjectMapping(0, 0, 0, [line("."), line("."), col("."), col(".")])<CR>
+au FileType python,coffee,haml,yaml,slim onoremap <buffer><silent>ii :<C-u>cal <Sid>HandleTextObjectMapping(1, 0, 0, [line("."), line("."), col("."), col(".")])<CR>
+au FileType python,coffee,haml,yaml,slim vnoremap <buffer><silent>ai :<C-u>cal <Sid>HandleTextObjectMapping(0, 0, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
+au FileType python,coffee,haml,yaml,slim vnoremap <buffer><silent>ii :<C-u>cal <Sid>HandleTextObjectMapping(1, 0, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
 
 let s:l0 = -1
 let s:l1 = -1


### PR DESCRIPTION
Provide only one text object behaving differently depending on the
current filetype. It doesn't include the line below the indent text for
file types where indentantion is a part of the syntax. Currently it
means Python, CoffeeScript, and Haml buffers. This can be extended as
necessary.

If accepted the doc/indent-object.txt should be changed accordingly.
