### PR TITLE
adding option to disable exceptional textobject behaviour at first level

### DIFF
--- a/doc/indent-object.txt
+++ b/doc/indent-object.txt
@@ -86,6 +86,12 @@ this case if blank lines are ignored, then the entire file would be selected.
 Instead when code at the top level is being indented blank lines are
 considered to delimit the block.
 
+This exceptional behaviour can be disabled by executing the following line
+>
+      :let g:indent_object_except_first_level = 0
+<
+(default is 1)
+
 
 ==============================================================================
 ABOUT                                                          *idntobj-about*

--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -114,7 +114,7 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
         " indent (skipping blank lines).
         let blnk = getline(l_1) =~ "^\\s*$"
         while l_1 > 0 && (blnk || indent(l_1) >= idnt)
-            if exists("g:indent_object_except_first_level") && idnt == 0 && blnk
+            if g:indent_object_except_first_level && idnt == 0 && blnk
                 break
             endif
             if !blnk || !a:inner
@@ -129,7 +129,7 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
         let line_cnt = line("$")
         let blnk = getline(l2) =~ "^\\s*$"
         while l2 <= line_cnt && (blnk || indent(l2) >= idnt)
-            if exists("g:indent_object_except_first_level") && idnt == 0 && blnk
+            if g:indent_object_except_first_level && idnt == 0 && blnk
                 break
             endif
             if !blnk || !a:inner

--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -42,193 +42,193 @@ let s:c0 = -1
 let s:c1 = -1
 
 if !exists("g:indent_object_except_first_level")
-   let g:indent_object_except_first_level = 1
+	let g:indent_object_except_first_level = 1
 endif
 
 function! <Sid>TextObject(inner, incbelow, vis, range, count)
 
-    " Record the current state of the visual region.
-    let vismode = "V"
+	" Record the current state of the visual region.
+	let vismode = "V"
 
-    " Detect if this is a completely new visual selction session.
-    let new_vis = 0
-    let new_vis = new_vis || s:l0 != a:range[0]
-    let new_vis = new_vis || s:l1 != a:range[1]
-    let new_vis = new_vis || s:c0 != a:range[2]
-    let new_vis = new_vis || s:c1 != a:range[3]
+	" Detect if this is a completely new visual selction session.
+	let new_vis = 0
+	let new_vis = new_vis || s:l0 != a:range[0]
+	let new_vis = new_vis || s:l1 != a:range[1]
+	let new_vis = new_vis || s:c0 != a:range[2]
+	let new_vis = new_vis || s:c1 != a:range[3]
 
-    let s:l0 = a:range[0]
-    let s:l1 = a:range[1]
-    let s:c0 = a:range[2]
-    let s:c1 = a:range[3]
+	let s:l0 = a:range[0]
+	let s:l1 = a:range[1]
+	let s:c0 = a:range[2]
+	let s:c1 = a:range[3]
 
-    " Repeatedly increase the scope of the selection.
-    let itr_cnt = 0
-    let cnt = a:count
-    while cnt > 0
+	" Repeatedly increase the scope of the selection.
+	let itr_cnt = 0
+	let cnt = a:count
+	while cnt > 0
 
-        " Look for the minimum indentation in the current visual region.
-        let l = s:l0
-        let idnt_invalid = 1000
-        let idnt = idnt_invalid
-        while l <= s:l1
-            if !(getline(l) =~ "^\\s*$")
-                let idnt = min([idnt, indent(l)])
-            endif
-            let l += 1
-        endwhile
+		" Look for the minimum indentation in the current visual region.
+		let l = s:l0
+		let idnt_invalid = 1000
+		let idnt = idnt_invalid
+		while l <= s:l1
+			if !(getline(l) =~ "^\\s*$")
+				let idnt = min([idnt, indent(l)])
+			endif
+			let l += 1
+		endwhile
 
-        " Keep track of where the range should be expanded to.
-        let l_1 = s:l0
-        let l_1o = l_1
-        let l2 = s:l1
-        let l2o = l2
+		" Keep track of where the range should be expanded to.
+		let l_1 = s:l0
+		let l_1o = l_1
+		let l2 = s:l1
+		let l2o = l2
 
-        " If we are highlighting only blank lines, we may not have found a
-        " valid indent. In this case we need to look for the next and previous
-        " non blank lines and check which of those has the largest indent.
-        if idnt == idnt_invalid
-            let idnt = 0
-            let pnb = prevnonblank(s:l0)
-            if pnb
-                let idnt = max([idnt, indent(pnb)])
-                let l_1 = pnb
-            endif
-            let nnb = nextnonblank(s:l0)
-            if nnb
-                let idnt = max([idnt, indent(nnb)])
-            endif
+		" If we are highlighting only blank lines, we may not have found a
+		" valid indent. In this case we need to look for the next and previous
+		" non blank lines and check which of those has the largest indent.
+		if idnt == idnt_invalid
+			let idnt = 0
+			let pnb = prevnonblank(s:l0)
+			if pnb
+				let idnt = max([idnt, indent(pnb)])
+				let l_1 = pnb
+			endif
+			let nnb = nextnonblank(s:l0)
+			if nnb
+				let idnt = max([idnt, indent(nnb)])
+			endif
 
-            " If we are in whitespace at the beginning of a block, skip over
-            " it when we are selecting the range. Similarly, if we are in
-            " whitespace at the end, ignore it.
-            if idnt > indent(pnb)
-                let l_1 = nnb
-            endif
-            if idnt > indent(nnb)
-                let l2 = pnb
-            endif
-        endif
+			" If we are in whitespace at the beginning of a block, skip over
+			" it when we are selecting the range. Similarly, if we are in
+			" whitespace at the end, ignore it.
+			if idnt > indent(pnb)
+				let l_1 = nnb
+			endif
+			if idnt > indent(nnb)
+				let l2 = pnb
+			endif
+		endif
 
-        " Search backward for the first line with less indent than the target
-        " indent (skipping blank lines).
-        let blnk = getline(l_1) =~ "^\\s*$"
-        while l_1 > 0 && (blnk || indent(l_1) >= idnt)
-            if g:indent_object_except_first_level && idnt == 0 && blnk
-                break
-            endif
-            if !blnk || !a:inner
-                let l_1o = l_1
-            endif
-            let l_1 -= 1
-            let blnk = getline(l_1) =~ "^\\s*$"
-        endwhile
+		" Search backward for the first line with less indent than the target
+		" indent (skipping blank lines).
+		let blnk = getline(l_1) =~ "^\\s*$"
+		while l_1 > 0 && (blnk || indent(l_1) >= idnt)
+			if g:indent_object_except_first_level && idnt == 0 && blnk
+				break
+			endif
+			if !blnk || !a:inner
+				let l_1o = l_1
+			endif
+			let l_1 -= 1
+			let blnk = getline(l_1) =~ "^\\s*$"
+		endwhile
 
-        " Search forward for the first line with more indent than the target
-        " indent (skipping blank lines).
-        let line_cnt = line("$")
-        let blnk = getline(l2) =~ "^\\s*$"
-        while l2 <= line_cnt && (blnk || indent(l2) >= idnt)
-            if g:indent_object_except_first_level && idnt == 0 && blnk
-                break
-            endif
-            if !blnk || !a:inner
-                let l2o = l2
-            endif
-            let l2 += 1
-            let blnk = getline(l2) =~ "^\\s*$"
-        endwhile
+		" Search forward for the first line with more indent than the target
+		" indent (skipping blank lines).
+		let line_cnt = line("$")
+		let blnk = getline(l2) =~ "^\\s*$"
+		while l2 <= line_cnt && (blnk || indent(l2) >= idnt)
+			if g:indent_object_except_first_level && idnt == 0 && blnk
+				break
+			endif
+			if !blnk || !a:inner
+				let l2o = l2
+			endif
+			let l2 += 1
+			let blnk = getline(l2) =~ "^\\s*$"
+		endwhile
 
-        " Determine which of these extensions to include. Include neither if
-        " we are selecting an 'inner' object. Exclude the bottom unless are
-        " told to include it.
-        let idnt2 = max([indent(l_1), indent(l2)])
-        if indent(l_1) < idnt2 || a:inner
-            let l_1 = l_1o
-        endif
-        if indent(l2) < idnt2 || a:inner || !a:incbelow
-            let l2 = l2o
-        endif
-        let l_1 = max([l_1, 1])
-        let l2 = min([l2, line("$")])
+		" Determine which of these extensions to include. Include neither if
+		" we are selecting an 'inner' object. Exclude the bottom unless are
+		" told to include it.
+		let idnt2 = max([indent(l_1), indent(l2)])
+		if indent(l_1) < idnt2 || a:inner
+			let l_1 = l_1o
+		endif
+		if indent(l2) < idnt2 || a:inner || !a:incbelow
+			let l2 = l2o
+		endif
+		let l_1 = max([l_1, 1])
+		let l2 = min([l2, line("$")])
 
-        " Extend the columns to the start and end.
-        " If inner is selected, set the final cursor pos to the start
-        " of the text in the line.
-        let c_1 = 1
-        if a:inner
-            let c_1 = match(getline(l_1), "\\c\\S") + 1
-        endif
-        let c2 = len(getline(l2))
-        if !a:inner
-            let c2 += 1
-        endif
+		" Extend the columns to the start and end.
+		" If inner is selected, set the final cursor pos to the start
+		" of the text in the line.
+		let c_1 = 1
+		if a:inner
+			let c_1 = match(getline(l_1), "\\c\\S") + 1
+		endif
+		let c2 = len(getline(l2))
+		if !a:inner
+			let c2 += 1
+		endif
 
-        " Make sure there's no change if we haven't really made a
-        " significant change in linewise mode - this makes sure that
-        " we can iteratively increase selection in linewise mode.
-        if itr_cnt == 0 && vismode ==# 'V' && s:l0 == l_1 && s:l1 == l2
-            let c_1 = s:c0
-            let c2 = s:c1
-        endif
+		" Make sure there's no change if we haven't really made a
+		" significant change in linewise mode - this makes sure that
+		" we can iteratively increase selection in linewise mode.
+		if itr_cnt == 0 && vismode ==# 'V' && s:l0 == l_1 && s:l1 == l2
+			let c_1 = s:c0
+			let c2 = s:c1
+		endif
 
-        " Check whether the visual region has changed.
-        let chg = 0
-        let chg = chg || s:l0 != l_1
-        let chg = chg || s:l1 != l2
-        let chg = chg || s:c0 != c_1
-        let chg = chg || s:c1 != c2
+		" Check whether the visual region has changed.
+		let chg = 0
+		let chg = chg || s:l0 != l_1
+		let chg = chg || s:l1 != l2
+		let chg = chg || s:c0 != c_1
+		let chg = chg || s:c1 != c2
 
-        if vismode ==# 'V' && new_vis
-            let chg = 1
-        endif
+		if vismode ==# 'V' && new_vis
+			let chg = 1
+		endif
 
-        " Update the vars.
-        let s:l0 = l_1
-        let s:l1 = l2
-        let s:c0 = c_1
-        let s:c1 = c2
+		" Update the vars.
+		let s:l0 = l_1
+		let s:l1 = l2
+		let s:c0 = c_1
+		let s:c1 = c2
 
-        " If there was no change, then don't decrement the count (it didn't
-        " count because it didn't do anything).
-        if chg
-            let cnt = cnt - 1
-        else
-            " Since this didn't work, push the selection back one char. This
-            " will have the effect of getting the enclosing block. Do it at
-            " the beginning rather than the end - the beginning is very likely
-            " to be only one indentation level different.
-            if s:l0 == 0
-                return
-            endif
-            let s:l0 -= 1
-            let s:c0 = len(getline(s:l0))
-        endif
+		" If there was no change, then don't decrement the count (it didn't
+		" count because it didn't do anything).
+		if chg
+			let cnt = cnt - 1
+		else
+			" Since this didn't work, push the selection back one char. This
+			" will have the effect of getting the enclosing block. Do it at
+			" the beginning rather than the end - the beginning is very likely
+			" to be only one indentation level different.
+			if s:l0 == 0
+				return
+			endif
+			let s:l0 -= 1
+			let s:c0 = len(getline(s:l0))
+		endif
 
-        let itr_cnt += 1
+		let itr_cnt += 1
 
-    endwhile
+	endwhile
 
-    " Apply the range we have found. Make sure to use the current visual mode.
-    call cursor(s:l0, s:c0)
-    exe "normal! " . vismode
-    call cursor(s:l1, s:c1)
-    normal! o
+	" Apply the range we have found. Make sure to use the current visual mode.
+	call cursor(s:l0, s:c0)
+	exe "normal! " . vismode
+	call cursor(s:l1, s:c1)
+	normal! o
 
-    " Update these static variables - we need to keep these up-to-date between
-    " invocations because it's the only way we can detect whether it's a new
-    " visual mode. We need to know if it's a new visual mode because otherwise
-    " if there's a single line block in visual line mode and we select it with
-    " "V", we can't tell whether it's already been selected using Vii.
-    exe "normal! \<Esc>"
-    let s:l0 = line("'<")
-    let s:l1 = line("'>")
-    let s:c0 = col("'<")
-    let s:c1 = col("'>")
-    normal gv
+	" Update these static variables - we need to keep these up-to-date between
+	" invocations because it's the only way we can detect whether it's a new
+	" visual mode. We need to know if it's a new visual mode because otherwise
+	" if there's a single line block in visual line mode and we select it with
+	" "V", we can't tell whether it's already been selected using Vii.
+	exe "normal! \<Esc>"
+	let s:l0 = line("'<")
+	let s:l1 = line("'>")
+	let s:c0 = col("'<")
+	let s:c1 = col("'>")
+	normal gv
 
 endfunction
 
 function! <Sid>HandleTextObjectMapping(inner, incbelow, vis, range)
-    call <Sid>TextObject(a:inner, a:incbelow, a:vis, a:range, v:count1)
+	call <Sid>TextObject(a:inner, a:incbelow, a:vis, a:range, v:count1)
 endfunction

--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -42,7 +42,7 @@ let s:c0 = -1
 let s:c1 = -1
 
 if !exists("g:indent_object_except_first_level")
-   let g:indent_object_except_first_level = 0
+   let g:indent_object_except_first_level = 1
 endif
 
 function! <Sid>TextObject(inner, incbelow, vis, range, count)

--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -10,10 +10,10 @@
 "  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 "  sell copies of the Software, and to permit persons to whom the Software is
 "  furnished to do so, subject to the following conditions:
-"  
+"
 "  The above copyright notice and this permission notice shall be included in
 "  all copies or substantial portions of the Software.
-"  
+"
 "  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 "  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 "  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -43,182 +43,182 @@ let s:c1 = -1
 
 function! <Sid>TextObject(inner, incbelow, vis, range, count)
 
-	" Record the current state of the visual region.
-	let vismode = "V"
+    " Record the current state of the visual region.
+    let vismode = "V"
 
-	" Detect if this is a completely new visual selction session.
-	let new_vis = 0
-	let new_vis = new_vis || s:l0 != a:range[0]
-	let new_vis = new_vis || s:l1 != a:range[1]
-	let new_vis = new_vis || s:c0 != a:range[2]
-	let new_vis = new_vis || s:c1 != a:range[3]
+    " Detect if this is a completely new visual selction session.
+    let new_vis = 0
+    let new_vis = new_vis || s:l0 != a:range[0]
+    let new_vis = new_vis || s:l1 != a:range[1]
+    let new_vis = new_vis || s:c0 != a:range[2]
+    let new_vis = new_vis || s:c1 != a:range[3]
 
-	let s:l0 = a:range[0]
-	let s:l1 = a:range[1]
-	let s:c0 = a:range[2]
-	let s:c1 = a:range[3]
+    let s:l0 = a:range[0]
+    let s:l1 = a:range[1]
+    let s:c0 = a:range[2]
+    let s:c1 = a:range[3]
 
-	" Repeatedly increase the scope of the selection.
-	let itr_cnt = 0
-	let cnt = a:count
-	while cnt > 0
+    " Repeatedly increase the scope of the selection.
+    let itr_cnt = 0
+    let cnt = a:count
+    while cnt > 0
 
-		" Look for the minimum indentation in the current visual region.
-		let l = s:l0
-		let idnt_invalid = 1000
-		let idnt = idnt_invalid
-		while l <= s:l1
-			if !(getline(l) =~ "^\\s*$")
-				let idnt = min([idnt, indent(l)])
-			endif
-			let l += 1
-		endwhile
+        " Look for the minimum indentation in the current visual region.
+        let l = s:l0
+        let idnt_invalid = 1000
+        let idnt = idnt_invalid
+        while l <= s:l1
+            if !(getline(l) =~ "^\\s*$")
+                let idnt = min([idnt, indent(l)])
+            endif
+            let l += 1
+        endwhile
 
-		" Keep track of where the range should be expanded to.
-		let l_1 = s:l0
-		let l_1o = l_1
-		let l2 = s:l1
-		let l2o = l2
+        " Keep track of where the range should be expanded to.
+        let l_1 = s:l0
+        let l_1o = l_1
+        let l2 = s:l1
+        let l2o = l2
 
-		" If we are highlighting only blank lines, we may not have found a
-		" valid indent. In this case we need to look for the next and previous
-		" non blank lines and check which of those has the largest indent.
-		if idnt == idnt_invalid
-			let idnt = 0
-			let pnb = prevnonblank(s:l0)
-			if pnb
-				let idnt = max([idnt, indent(pnb)])
-				let l_1 = pnb
-			endif
-			let nnb = nextnonblank(s:l0)
-			if nnb
-				let idnt = max([idnt, indent(nnb)])
-			endif
+        " If we are highlighting only blank lines, we may not have found a
+        " valid indent. In this case we need to look for the next and previous
+        " non blank lines and check which of those has the largest indent.
+        if idnt == idnt_invalid
+            let idnt = 0
+            let pnb = prevnonblank(s:l0)
+            if pnb
+                let idnt = max([idnt, indent(pnb)])
+                let l_1 = pnb
+            endif
+            let nnb = nextnonblank(s:l0)
+            if nnb
+                let idnt = max([idnt, indent(nnb)])
+            endif
 
-			" If we are in whitespace at the beginning of a block, skip over
-			" it when we are selecting the range. Similarly, if we are in
-			" whitespace at the end, ignore it.
-			if idnt > indent(pnb)
-				let l_1 = nnb
-			endif
-			if idnt > indent(nnb)
-				let l2 = pnb
-			endif
-		endif
+            " If we are in whitespace at the beginning of a block, skip over
+            " it when we are selecting the range. Similarly, if we are in
+            " whitespace at the end, ignore it.
+            if idnt > indent(pnb)
+                let l_1 = nnb
+            endif
+            if idnt > indent(nnb)
+                let l2 = pnb
+            endif
+        endif
 
-		" Search backward for the first line with less indent than the target
-		" indent (skipping blank lines).
-		let blnk = getline(l_1) =~ "^\\s*$"
-		while l_1 > 0 && ((idnt == 0 && !blnk) || (idnt != 0 && (blnk || indent(l_1) >= idnt)))
-			if !blnk || !a:inner
-				let l_1o = l_1
-			endif
-			let l_1 -= 1
-			let blnk = getline(l_1) =~ "^\\s*$"
-		endwhile
+        " Search backward for the first line with less indent than the target
+        " indent (skipping blank lines).
+        let blnk = getline(l_1) =~ "^\\s*$"
+        while l_1 > 0 && ((idnt == 0 && !blnk) || (idnt != 0 && (blnk || indent(l_1) >= idnt)))
+            if !blnk || !a:inner
+                let l_1o = l_1
+            endif
+            let l_1 -= 1
+            let blnk = getline(l_1) =~ "^\\s*$"
+        endwhile
 
-		" Search forward for the first line with more indent than the target
-		" indent (skipping blank lines).
-		let line_cnt = line("$")
-		let blnk = getline(l2) =~ "^\\s*$"
-		while l2 <= line_cnt && ((idnt == 0 && !blnk) || (idnt != 0 && (blnk || indent(l2) >= idnt)))
-			if !blnk || !a:inner
-				let l2o = l2
-			endif
-			let l2 += 1
-			let blnk = getline(l2) =~ "^\\s*$"
-		endwhile
+        " Search forward for the first line with more indent than the target
+        " indent (skipping blank lines).
+        let line_cnt = line("$")
+        let blnk = getline(l2) =~ "^\\s*$"
+        while l2 <= line_cnt && ((idnt == 0 && !blnk) || (idnt != 0 && (blnk || indent(l2) >= idnt)))
+            if !blnk || !a:inner
+                let l2o = l2
+            endif
+            let l2 += 1
+            let blnk = getline(l2) =~ "^\\s*$"
+        endwhile
 
-		" Determine which of these extensions to include. Include neither if
-		" we are selecting an 'inner' object. Exclude the bottom unless are
-		" told to include it.
-		let idnt2 = max([indent(l_1), indent(l2)])
-		if indent(l_1) < idnt2 || a:inner
-			let l_1 = l_1o
-		endif
-		if indent(l2) < idnt2 || a:inner || !a:incbelow
-			let l2 = l2o
-		endif
-		let l_1 = max([l_1, 1])
-		let l2 = min([l2, line("$")])
+        " Determine which of these extensions to include. Include neither if
+        " we are selecting an 'inner' object. Exclude the bottom unless are
+        " told to include it.
+        let idnt2 = max([indent(l_1), indent(l2)])
+        if indent(l_1) < idnt2 || a:inner
+            let l_1 = l_1o
+        endif
+        if indent(l2) < idnt2 || a:inner || !a:incbelow
+            let l2 = l2o
+        endif
+        let l_1 = max([l_1, 1])
+        let l2 = min([l2, line("$")])
 
-		" Extend the columns to the start and end.
-		" If inner is selected, set the final cursor pos to the start
-		" of the text in the line.
-		let c_1 = 1
-		if a:inner
-			let c_1 = match(getline(l_1), "\\c\\S") + 1
-		endif
-		let c2 = len(getline(l2))
-		if !a:inner
-			let c2 += 1
-		endif
+        " Extend the columns to the start and end.
+        " If inner is selected, set the final cursor pos to the start
+        " of the text in the line.
+        let c_1 = 1
+        if a:inner
+            let c_1 = match(getline(l_1), "\\c\\S") + 1
+        endif
+        let c2 = len(getline(l2))
+        if !a:inner
+            let c2 += 1
+        endif
 
-		" Make sure there's no change if we haven't really made a
-		" significant change in linewise mode - this makes sure that
-		" we can iteratively increase selection in linewise mode.
-		if itr_cnt == 0 && vismode ==# 'V' && s:l0 == l_1 && s:l1 == l2
-			let c_1 = s:c0
-			let c2 = s:c1
-		endif
+        " Make sure there's no change if we haven't really made a
+        " significant change in linewise mode - this makes sure that
+        " we can iteratively increase selection in linewise mode.
+        if itr_cnt == 0 && vismode ==# 'V' && s:l0 == l_1 && s:l1 == l2
+            let c_1 = s:c0
+            let c2 = s:c1
+        endif
 
-		" Check whether the visual region has changed.
-		let chg = 0
-		let chg = chg || s:l0 != l_1
-		let chg = chg || s:l1 != l2
-		let chg = chg || s:c0 != c_1
-		let chg = chg || s:c1 != c2
+        " Check whether the visual region has changed.
+        let chg = 0
+        let chg = chg || s:l0 != l_1
+        let chg = chg || s:l1 != l2
+        let chg = chg || s:c0 != c_1
+        let chg = chg || s:c1 != c2
 
-		if vismode ==# 'V' && new_vis
-			let chg = 1
-		endif
+        if vismode ==# 'V' && new_vis
+            let chg = 1
+        endif
 
-		" Update the vars.
-		let s:l0 = l_1
-		let s:l1 = l2
-		let s:c0 = c_1
-		let s:c1 = c2
+        " Update the vars.
+        let s:l0 = l_1
+        let s:l1 = l2
+        let s:c0 = c_1
+        let s:c1 = c2
 
-		" If there was no change, then don't decrement the count (it didn't
-		" count because it didn't do anything).
-		if chg
-			let cnt = cnt - 1
-		else
-			" Since this didn't work, push the selection back one char. This
-			" will have the effect of getting the enclosing block. Do it at
-			" the beginning rather than the end - the beginning is very likely
-			" to be only one indentation level different.
-			if s:l0 == 0
-				return
-			endif
-			let s:l0 -= 1
-			let s:c0 = len(getline(s:l0))
-		endif
+        " If there was no change, then don't decrement the count (it didn't
+        " count because it didn't do anything).
+        if chg
+            let cnt = cnt - 1
+        else
+            " Since this didn't work, push the selection back one char. This
+            " will have the effect of getting the enclosing block. Do it at
+            " the beginning rather than the end - the beginning is very likely
+            " to be only one indentation level different.
+            if s:l0 == 0
+                return
+            endif
+            let s:l0 -= 1
+            let s:c0 = len(getline(s:l0))
+        endif
 
-		let itr_cnt += 1
+        let itr_cnt += 1
 
-	endwhile
+    endwhile
 
-	" Apply the range we have found. Make sure to use the current visual mode.
-	call cursor(s:l0, s:c0)
-	exe "normal! " . vismode
-	call cursor(s:l1, s:c1)
-	normal! o
+    " Apply the range we have found. Make sure to use the current visual mode.
+    call cursor(s:l0, s:c0)
+    exe "normal! " . vismode
+    call cursor(s:l1, s:c1)
+    normal! o
 
-	" Update these static variables - we need to keep these up-to-date between
-	" invocations because it's the only way we can detect whether it's a new
-	" visual mode. We need to know if it's a new visual mode because otherwise
-	" if there's a single line block in visual line mode and we select it with
-	" "V", we can't tell whether it's already been selected using Vii.
-	exe "normal! \<Esc>"
-	let s:l0 = line("'<")
-	let s:l1 = line("'>")
-	let s:c0 = col("'<")
-	let s:c1 = col("'>")
-	normal gv
+    " Update these static variables - we need to keep these up-to-date between
+    " invocations because it's the only way we can detect whether it's a new
+    " visual mode. We need to know if it's a new visual mode because otherwise
+    " if there's a single line block in visual line mode and we select it with
+    " "V", we can't tell whether it's already been selected using Vii.
+    exe "normal! \<Esc>"
+    let s:l0 = line("'<")
+    let s:l1 = line("'>")
+    let s:c0 = col("'<")
+    let s:c1 = col("'>")
+    normal gv
 
 endfunction
 
 function! <Sid>HandleTextObjectMapping(inner, incbelow, vis, range)
-	call <Sid>TextObject(a:inner, a:incbelow, a:vis, a:range, v:count1)
+    call <Sid>TextObject(a:inner, a:incbelow, a:vis, a:range, v:count1)
 endfunction

--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -114,7 +114,7 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
         " indent (skipping blank lines).
         let blnk = getline(l_1) =~ "^\\s*$"
         while l_1 > 0 && (blnk || indent(l_1) >= idnt)
-            if exists("g:indent_object_except_first_level") && idnt == 0 && blank
+            if exists("g:indent_object_except_first_level") && idnt == 0 && blnk
                 break
             endif
             if !blnk || !a:inner
@@ -129,7 +129,7 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
         let line_cnt = line("$")
         let blnk = getline(l2) =~ "^\\s*$"
         while l2 <= line_cnt && (blnk || indent(l2) >= idnt)
-            if exists("g:indent_object_except_first_level") && idnt == 0 && blank
+            if exists("g:indent_object_except_first_level") && idnt == 0 && blnk
                 break
             endif
             if !blnk || !a:inner

--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -41,6 +41,10 @@ let s:l1 = -1
 let s:c0 = -1
 let s:c1 = -1
 
+if !exists("g:indent_object_except_first_level")
+   let g:indent_object_except_first_level = 0
+endif
+
 function! <Sid>TextObject(inner, incbelow, vis, range, count)
 
     " Record the current state of the visual region.
@@ -109,7 +113,10 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
         " Search backward for the first line with less indent than the target
         " indent (skipping blank lines).
         let blnk = getline(l_1) =~ "^\\s*$"
-        while l_1 > 0 && ((idnt == 0 && !blnk) || (idnt != 0 && (blnk || indent(l_1) >= idnt)))
+        while l_1 > 0 && (blnk || indent(l_1) >= idnt)
+            if exists("g:indent_object_except_first_level") && idnt == 0 && blank
+                break
+            endif
             if !blnk || !a:inner
                 let l_1o = l_1
             endif
@@ -121,7 +128,10 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
         " indent (skipping blank lines).
         let line_cnt = line("$")
         let blnk = getline(l2) =~ "^\\s*$"
-        while l2 <= line_cnt && ((idnt == 0 && !blnk) || (idnt != 0 && (blnk || indent(l2) >= idnt)))
+        while l2 <= line_cnt && (blnk || indent(l2) >= idnt)
+            if exists("g:indent_object_except_first_level") && idnt == 0 && blank
+                break
+            endif
             if !blnk || !a:inner
                 let l2o = l2
             endif


### PR DESCRIPTION
the code change is minimal and the default behaviour is not changed
the new parameter with default value: ``let g:indent_object_except_first_level = 1``
(setting this to ``0`` will make the indent-textobj working the same also on the first level, i.e. selecting the whole file here)
