### PR TITLE
Make iI do something different than ii

### DIFF
--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -25,16 +25,16 @@
 "--------------------------------------------------------------------------------
 
 " Mappings excluding line below.
-onoremap <silent>ai :<C-u>cal <Sid>HandleTextObjectMapping(0, 0, 0, [line("."), line("."), col("."), col(".")])<CR>
-onoremap <silent>ii :<C-u>cal <Sid>HandleTextObjectMapping(1, 0, 0, [line("."), line("."), col("."), col(".")])<CR>
-vnoremap <silent>ai :<C-u>cal <Sid>HandleTextObjectMapping(0, 0, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
-vnoremap <silent>ii :<C-u>cal <Sid>HandleTextObjectMapping(1, 0, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
+onoremap <silent>ai :<C-u>cal <Sid>HandleTextObjectMapping(0, 0, 0, 0, [line("."), line("."), col("."), col(".")])<CR>
+onoremap <silent>ii :<C-u>cal <Sid>HandleTextObjectMapping(1, 0, 0, 0, [line("."), line("."), col("."), col(".")])<CR>
+vnoremap <silent>ai :<C-u>cal <Sid>HandleTextObjectMapping(0, 0, 0, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
+vnoremap <silent>ii :<C-u>cal <Sid>HandleTextObjectMapping(1, 0, 0, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
 
 " Mappings including line below.
-onoremap <silent>aI :<C-u>cal <Sid>HandleTextObjectMapping(0, 1, 0, [line("."), line("."), col("."), col(".")])<CR>
-onoremap <silent>iI :<C-u>cal <Sid>HandleTextObjectMapping(1, 1, 0, [line("."), line("."), col("."), col(".")])<CR>
-vnoremap <silent>aI :<C-u>cal <Sid>HandleTextObjectMapping(0, 1, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
-vnoremap <silent>iI :<C-u>cal <Sid>HandleTextObjectMapping(1, 1, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
+onoremap <silent>aI :<C-u>cal <Sid>HandleTextObjectMapping(0, 0, 1, 0, [line("."), line("."), col("."), col(".")])<CR>
+onoremap <silent>iI :<C-u>cal <Sid>HandleTextObjectMapping(0, 1, 1, 0, [line("."), line("."), col("."), col(".")])<CR>
+vnoremap <silent>aI :<C-u>cal <Sid>HandleTextObjectMapping(0, 0, 1, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
+vnoremap <silent>iI :<C-u>cal <Sid>HandleTextObjectMapping(0, 1, 1, 1, [line("'<"), line("'>"), col("'<"), col("'>")])<CR><Esc>gv
 
 let s:l0 = -1
 let s:l1 = -1
@@ -45,7 +45,7 @@ if !exists("g:indent_object_except_first_level")
 	let g:indent_object_except_first_level = 1
 endif
 
-function! <Sid>TextObject(inner, incbelow, vis, range, count)
+function! <Sid>TextObject(inner, incabove, incbelow, vis, range, count)
 
 	" Record the current state of the visual region.
 	let vismode = "V"
@@ -123,6 +123,22 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
 			let l_1 -= 1
 			let blnk = getline(l_1) =~ "^\\s*$"
 		endwhile
+
+		" Try search backward to the next line with the same indent as l_1
+		if a:incabove
+			let original_l1_idnt = indent(l_1)
+			let l1_save = l_1
+			while l_1 > 1
+				let l_1 -= 1
+				let blnk = getline(l_1) =~ "^\\s*$"
+				if indent(l_1) == original_l1_idnt
+					break
+				elseif indent(l_1) != original_l1_idnt && !blnk
+					let l_1 = l1_save
+					break
+				endif
+			endwhile
+		endif
 
 		" Search forward for the first line with more indent than the target
 		" indent (skipping blank lines).
@@ -229,6 +245,6 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
 
 endfunction
 
-function! <Sid>HandleTextObjectMapping(inner, incbelow, vis, range)
-	call <Sid>TextObject(a:inner, a:incbelow, a:vis, a:range, v:count1)
+function! <Sid>HandleTextObjectMapping(inner, incabove, incbelow, vis, range)
+	call <Sid>TextObject(a:inner, a:incabove, a:incbelow, a:vis, a:range, v:count1)
 endfunction


### PR DESCRIPTION
Hello! First off, thanks for writing this plugin :). It's so handy in a lot of different programming scenarios. I do have one feature request though which I think I've correctly implemented in this PR. In short I want to be able to select entire constructs that look like this:

```bash
for i in {1..10}
do
    echo $i; # Cursor on this line
done
```

Or this:

```C
for(i = 1; i <= 10; i++)
{
    printf("%d\n", i); // Cursor on this line
}
```

In the above examples, I want to have my cursor on the ```echo``` or ```printf``` lines and select the entire ```for``` loop in one go. ```aI``` gets close but doesn't quite make it. Since the ```iI``` mapping wasn't doing anything useful I repurposed it to perform this task.  More specifically, ```iI``` selects the same region as ```aI``` then tries to nudge the top of the text object up to the next line that has the same indent as the line at the top of the region that ```aI``` would select.

Making the ```iI``` mapping select the "biggest" text object is a bit counterintuitive but since it was free I just decided to use it. When I was making this PR I was also thinking that maybe (if you like it) we could change what region each text object selects so it makes a bit more sense (or, more simply, we could provide ```<Plug>``` mappings so users can do it themselves). I was thinking that ```iI``` becomes ```ai```, ```ai``` becomes ```aI```, and ```aI``` becomes my implementation of ```iI```. But that's just idle thinking on my part.

Let me know what you think!