### PR TITLE
Stop cursor on the last line after selecting text by `vii`

### DIFF
--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -225,7 +225,7 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
 	let s:l1 = line("'>")
 	let s:c0 = col("'<")
 	let s:c1 = col("'>")
-	normal gvo0
+	normal gv0o0
 
 endfunction
 

--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -225,7 +225,7 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
 	let s:l1 = line("'>")
 	let s:c0 = col("'<")
 	let s:c1 = col("'>")
-	normal gv
+	normal gvo0
 
 endfunction
 


### PR DESCRIPTION
Keep corresponding bahavior like `vip`.

see the below for details:

https://github.com/michaeljsmith/vim-indent-object/issues/15