### PR TITLE
Add ignore blank line option

### DIFF
--- a/doc/indent-object.txt
+++ b/doc/indent-object.txt
@@ -92,6 +92,12 @@ This exceptional behaviour can be disabled by executing the following line
 <
 (default is 1)
 
+Also, blank line behaviour can be disabled by executing the following lne
+>
+      :let g:indent_object_ignore_blank_line = 0
+<
+(default is 1)
+
 
 ==============================================================================
 ABOUT                                                          *indtobj-about*

--- a/plugin/indent-object.vim
+++ b/plugin/indent-object.vim
@@ -45,6 +45,10 @@ if !exists("g:indent_object_except_first_level")
 	let g:indent_object_except_first_level = 1
 endif
 
+if !exists("g:indent_object_ignore_blank_line")
+	let g:indent_object_ignore_blank_line = 1
+endif
+
 function! <Sid>TextObject(inner, incbelow, vis, range, count)
 
 	" Record the current state of the visual region.
@@ -111,9 +115,9 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
 		endif
 
 		" Search backward for the first line with less indent than the target
-		" indent (skipping blank lines).
+		" indent.
 		let blnk = getline(l_1) =~ "^\\s*$"
-		while l_1 > 0 && (blnk || indent(l_1) >= idnt)
+		while l_1 > 0 && (g:indent_object_ignore_blank_line || indent(l_1) >= idnt)
 			if g:indent_object_except_first_level && idnt == 0 && blnk
 				break
 			endif
@@ -125,10 +129,10 @@ function! <Sid>TextObject(inner, incbelow, vis, range, count)
 		endwhile
 
 		" Search forward for the first line with more indent than the target
-		" indent (skipping blank lines).
+		" indent.
 		let line_cnt = line("$")
 		let blnk = getline(l2) =~ "^\\s*$"
-		while l2 <= line_cnt && (blnk || indent(l2) >= idnt)
+		while l2 <= line_cnt && (g:indent_object_ignore_blank_line || indent(l2) >= idnt)
 			if g:indent_object_except_first_level && idnt == 0 && blnk
 				break
 			endif


### PR DESCRIPTION
blank line behavior can be disabled by executing the following line

```vim
      :let g:indent_object_ignore_blank_line = 0
```
(default is 1)